### PR TITLE
Profile improvements

### DIFF
--- a/stanford.make
+++ b/stanford.make
@@ -44,6 +44,7 @@ projects[imagefield] = 3.10
 projects[insert] = 1.1
 projects[job_scheduler] = 1.0-beta3
 projects[jquery_ui] = 1.4
+projects[libraries] = 1.0
 projects[link] = 2.9
 projects[mollom] = 1.15
 projects[nodeformcols] = 1.6

--- a/stanford.make
+++ b/stanford.make
@@ -61,9 +61,9 @@ projects[wysiwyg] = 2.3
 projects[stanford_events_importer][type] = module
 projects[stanford_events_importer][download][type] = file
 projects[stanford_events_importer][download][url] = 'https://techcommons.stanford.edu/files/stanford_events_importer-6.x-1.0-beta6.tar.gz'
-
-; need URLs
-;projects[] = webauth
+projects[webauth][type] = module
+projects[webauth][download][type] = file
+projects[webauth][download][url] = 'http://drupalfeatures.stanford.edu/sites/default/files/fserver/webauth-6.x-3.0.tar.gz'
 
 ; Themes
 

--- a/stanford.make
+++ b/stanford.make
@@ -44,7 +44,6 @@ projects[imagefield] = 3.10
 projects[insert] = 1.1
 projects[job_scheduler] = 1.0-beta3
 projects[jquery_ui] = 1.4
-projects[libraries] = 1.0
 projects[link] = 2.9
 projects[mollom] = 1.15
 projects[nodeformcols] = 1.6

--- a/stanford.profile
+++ b/stanford.profile
@@ -21,6 +21,7 @@ function stanford_profile_modules() {
                'help',
                'insert',
                'jquery_ui',
+               'libraries',
                'link',
                'menu',
                'nodeformcols',

--- a/stanford.profile
+++ b/stanford.profile
@@ -9,7 +9,6 @@
 function stanford_profile_modules() {
   return array('auto_nodetitle',
                'color',
-               'comment',
                'content',
                'css_injector',
                'dblog',

--- a/stanford.profile
+++ b/stanford.profile
@@ -130,7 +130,7 @@ function stanford_profile_tasks(&$task, $url) {
       'type' => 'page',
       'name' => st('Page'),
       'module' => 'node',
-      'description' => st("A <em>page</em>, similar in form to a <em>story</em>, is a simple method for creating and displaying information that rarely changes, such as an \"About us\" section of a website. By default, a <em>page</em> entry does not allow visitor comments and is not featured on the site's initial home page."),
+      'description' => st("A <em>page</em> is a simple method for creating and displaying information that rarely changes, such as an \"About us\" section of a website."),
       'custom' => TRUE,
       'modified' => TRUE,
       'locked' => FALSE,
@@ -144,8 +144,8 @@ function stanford_profile_tasks(&$task, $url) {
     node_type_save($type);
   }
 
-  // Default page to not be promoted and have comments disabled.
-  variable_set('node_options_page', array('status'));
+  // Default page to not be promoted, revisions enabled, and have comments disabled.
+  variable_set('node_options_page', array('status', 'revision'));
   variable_set('comment_page', COMMENT_NODE_DISABLED);
 
   // Don't display date and author information for page nodes by default.

--- a/stanford.profile
+++ b/stanford.profile
@@ -187,6 +187,12 @@ function stanford_profile_tasks(&$task, $url) {
   variable_set('date_default_timezone_name', $default_timezone_name);
   variable_set('date_default_timezone', $default_timezone_offset);
   
+  // Default upload quotas
+  $uploadsize_default = 2;
+  $usersize_default = 100;
+  variable_set('upload_uploadsize_default', $uploadsize_default);
+  variable_set('upload_usersize_default', $usersize_default);
+  
   // Create configuration for CKEditor
   $ckeditor_configuration = serialize(array (
     'default' => 1,

--- a/stanford.profile
+++ b/stanford.profile
@@ -173,6 +173,10 @@ function stanford_profile_tasks(&$task, $url) {
   $user_mail_register_no_approval_required_body = "!username,\n\nThank you for registering at !site. You may now log in to !login_uri using the following username and password:\n\nusername: !username\n\n\nYou may also log in by clicking on this link or copying and pasting it in your browser:\n\n!login_url\n\nThis is a one-time login, so it can be used only once.\n\nAfter logging in, you will be redirected to !edit_uri so you can change your password.\n\n\n--  !site team";
   variable_set('user_mail_register_no_approval_required_body', $user_mail_register_no_approval_required_body);
   
+  // User registration - only site administrators can create new user accounts
+  $user_register = 0;
+  variable_set('user_register', $user_register);
+  
   // Remove "Powered by Drupal" block from footer
   $block_module = 'system';
   db_query("UPDATE {blocks} SET status = %d WHERE module = '%s' AND delta = %d", 0, $block_module, 0);

--- a/stanford.profile
+++ b/stanford.profile
@@ -193,6 +193,10 @@ function stanford_profile_tasks(&$task, $url) {
   variable_set('upload_uploadsize_default', $uploadsize_default);
   variable_set('upload_usersize_default', $usersize_default);
   
+  // Error reporting
+  $error_level = 0;
+  variable_set('error_level', $error_level);
+  
   // Create configuration for CKEditor
   $ckeditor_configuration = serialize(array (
     'default' => 1,

--- a/stanford.profile
+++ b/stanford.profile
@@ -137,17 +137,6 @@ function stanford_profile_tasks(&$task, $url) {
       'help' => '',
       'min_word_count' => '',
     ),
-    array(
-      'type' => 'story',
-      'name' => st('Story'),
-      'module' => 'node',
-      'description' => st("A <em>story</em>, similar in form to a <em>page</em>, is ideal for creating and displaying content that informs or engages website visitors. Press releases, site announcements, and informal blog-like entries may all be created with a <em>story</em> entry. By default, a <em>story</em> entry is automatically featured on the site's initial home page, and provides the ability to post comments."),
-      'custom' => TRUE,
-      'modified' => TRUE,
-      'locked' => FALSE,
-      'help' => '',
-      'min_word_count' => '',
-    ),
   );
 
   foreach ($types as $type) {

--- a/stanford.profile
+++ b/stanford.profile
@@ -23,7 +23,6 @@ function stanford_profile_modules() {
                'help',
                'insert',
                'jquery_ui',
-               'libraries',
                'link',
                'menu',
                'nodeformcols',

--- a/stanford.profile
+++ b/stanford.profile
@@ -11,6 +11,8 @@ function stanford_profile_modules() {
                'color',
                'content',
                'css_injector',
+               'date_api',
+               'date_timezone',
                'dblog',
                'email',
                'features',
@@ -175,6 +177,16 @@ function stanford_profile_tasks(&$task, $url) {
   $block_module = 'system';
   db_query("UPDATE {blocks} SET status = %d WHERE module = '%s' AND delta = %d", 0, $block_module, 0);
 
+  // Disable user-configurable timezones by default
+  $user_configurable_timezones = 0;
+  variable_set('configurable_timezones', $user_configurable_timezones);
+  
+  // Set default timezone
+  $default_timezone_name = "America/Los_Angeles";
+  $default_timezone_offset = -28800;
+  variable_set('date_default_timezone_name', $default_timezone_name);
+  variable_set('date_default_timezone', $default_timezone_offset);
+  
   // Create configuration for CKEditor
   $ckeditor_configuration = serialize(array (
     'default' => 1,


### PR DESCRIPTION
This pull request includes a number of small improvements to the profile and its default settings.

To wit:

  disable story content type (https://github.com/SU-SWS/Stanford-Drupal-Profile/commit/3f759b0c3c03cbba7fc73f530b75c667106f7d0f)
  turn revisions on by default for page (https://github.com/SU-SWS/Stanford-Drupal-Profile/commit/3a0ce4531aca6be7956a0fff914c2d4c3fef0ba4)
  turn comment module off by default (https://github.com/SU-SWS/Stanford-Drupal-Profile/commit/dab6e47b98bbe94ea9c4335551464c2863c05dff)
  Date/Date API: enable date_api and date_timezone; disable user-configurable time zones (https://github.com/SU-SWS/Stanford-Drupal-Profile/commit/1a8d93fb1f3ec57a54e51b2b803b5e902b956857)
  File upload size per upload and per users (https://github.com/SU-SWS/Stanford-Drupal-Profile/commit/9d70588a7cff653c8ef21888efe9d3f6575ff409) 
  set error messages to only go to log (https://github.com/SU-SWS/Stanford-Drupal-Profile/commit/6808c2c752d53be0218b5ce04d01d9ad1ee32849)
  set user creation to only by administrator (https://github.com/SU-SWS/Stanford-Drupal-Profile/commit/83f21cf952f841679635b481aa05970dd565f2cb)
