### PR TITLE
Core and contrib updates

### DIFF
--- a/make/patches.make
+++ b/make/patches.make
@@ -7,6 +7,9 @@ projects[context_useragent][patch][] = "https://drupal.org/files/issues/context_
 ; https://www.drupal.org/node/2471911 Form validation fails with "the directory is not writable" when public file system is remote
 projects[css_injector][patch][] = "https://www.drupal.org/files/issues/css_injector-remove_drupal_realpath-2471911-2.patch"
 
+; https://www.drupal.org/node/2375235 Calendar block Next/Prev navigation broken
+projects[date][patch][] = "https://www.drupal.org/files/issues/calendar_pager_broken-2375235-35.patch"
+
 ; https://drupal.org/node/927566 & https://drupal.org/node/860974 | Menu Links will not import/revert
 projects[features][patch][] = "https://drupal.org/files/issues/features-parent_identifier-927566-79.patch"
 

--- a/make/stanford.make
+++ b/make/stanford.make
@@ -1,7 +1,7 @@
 core = 7.x
 
 api = 2
-projects[drupal][version] = "7.38"
+projects[drupal][version] = "7.39"
 
 ; Contributed modules
 projects[admin_menu][subdir] = "contrib"
@@ -47,7 +47,7 @@ projects[context_list_active][version] = "1.0"
 projects[context_respect][subdir] = "contrib"
 projects[context_respect][version] = "1.3"
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.7"
+projects[ctools][version] = "1.9"
 projects[custom_breadcrumbs][subdir] = "contrib"
 projects[custom_breadcrumbs][version] = "1.0-alpha1"
 projects[date][subdir] = "contrib"


### PR DESCRIPTION
drupal 7.38
ctools 7.x-1.9
date patch: https://www.drupal.org/files/issues/calendar_pager_broken-2375235-35.patch
