### PR TITLE
Re-add css_injector patch from issue 2160385

### DIFF
--- a/make/patches.make
+++ b/make/patches.make
@@ -7,6 +7,9 @@ projects[context_useragent][patch][] = "https://drupal.org/files/issues/context_
 ; https://www.drupal.org/node/2471911 Form validation fails with "the directory is not writable" when public file system is remote
 projects[css_injector][patch][] = "https://www.drupal.org/files/issues/css_injector-remove_drupal_realpath-2471911-2.patch"
 
+; https://www.drupal.org/node/2160385 - PHP notices after clicking "Edit rule"
+projects[css_injector][patch][] = "https://www.drupal.org/files/issues/css_injector-bad_crid_protection-2160385-10.patch"
+
 ; https://www.drupal.org/node/2375235 Calendar block Next/Prev navigation broken
 projects[date][patch][] = "https://www.drupal.org/files/issues/calendar_pager_broken-2375235-35.patch"
 


### PR DESCRIPTION
@sherakama this accidentally got removed way back in https://github.com/SU-SWS/stanford-jumpstart-deployer/commit/4b5be6169fcb6ef80b67a8c6bfa6e87834e58546. I'm not sure why, because it's not in 7.x-1.x-dev. Yikes.
