### PR TITLE
Revert stanford_page on install, as it is coming in overridden

### DIFF
--- a/stanford.install
+++ b/stanford.install
@@ -121,6 +121,7 @@ function stanford_install() {
     $query->values($block);
   }
   $query->execute();
+  features_revert_module('stanford_page');
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- What it says on the tin

# Needed By (Date)
- Next week sometime would be good. Stanford Page is borked for self-service installs

# Criticality
- How critical is this PR on a 1-10 scale? 5
- It affects every site on self-service. I don't believe JS* sites are affected.

# Steps to Test

1. Check out `7.x-2.x`
2. Run `drush si stanford`
3. See that `stanford_page` is overridden and that the body field does not appear when you try to create a `stanford_page` node
4. Check out this branch
5. Repeat Step 2
6. See that 3 is no longer the case

# Affected Projects or Products
- Self-service sites

