### PR TITLE
Change to path for jquery cycle

### DIFF
--- a/make/libraries.make
+++ b/make/libraries.make
@@ -21,7 +21,7 @@ libraries[icalcreator][directory_name] = "iCalcreator"
 libraries[icalcreator][destination] = "libraries"
 
 libraries[jquery_cycle][download][type] = "get"
-libraries[jquery_cycle][download][url] = "http://malsup.github.com/jquery.cycle.all.js"
+libraries[jquery_cycle][download][url] = "http://malsup.github.io/jquery.cycle.all.js"
 libraries[jquery_cycle][directory_name] = "jquery.cycle"
 libraries[jquery_cycle][destination] = "libraries"
 


### PR DESCRIPTION
# NOT READY - BROKE

# Summary
- Moved to http://malsup.github.io/jquery.cycle.all.js

# Needed By (Date)
- December 1st @ 12:01pm

# Urgency
- Stuff is breaking, so yeah, kinda portant.

# Steps to Test

1. Build
2. Ensure cycle library file is in the correct spot and has contents.

# Affected Projects or Products
- Errything on 4.x
- This Profile

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)