### PR TITLE
Update stanford.profile

### DIFF
--- a/stanford.profile
+++ b/stanford.profile
@@ -211,7 +211,6 @@ function stanford_acsf_tasks() {
     'acsf',
     'acsf_helper',
     'paranoia',
-    'newrelic_appname',
     'stanford_ssp',
     'stanford_saml_block'
   );


### PR DESCRIPTION
Remove newrelic_appname as it is no longer a dependency.