### PR TITLE
SITES-1101: Update block/bean titles

### DIFF
--- a/stanford.install
+++ b/stanford.install
@@ -249,3 +249,22 @@ function stanford_sites_install_configure_form_submit($form, &$form_state) {
   variable_set('stanford_sites_requester_email', $form['stanford_sites_requester_email']['#value']);
   variable_set('stanford_sites_auth_method', $form['stanford_authentication']['#value']);
 }
+
+/**
+ * Update all empty bean block titles with `<none>` because bean added the title
+ * to the template by default.
+ */
+function stanford_update_7300() {
+
+  // Updates all bean elements that had not explicitly set their block title to
+  // something to `<none>` so that an extra title doesn't show up in the
+  // bean module >= 1.13.
+  if (module_exists('bean')) {
+    db_update("block")
+      ->fields(['title' => '<none>'])
+      ->condition('module', 'bean')
+      ->condition('title', '')
+      ->execute();
+  }
+  
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Upgrade block bean titles so that bean 1.13 doesn't double up the title.
- Instead of removing the variable from the template set all existing blocks' titles to none so that they don't show duplicates.

# Needed By (Date)
- ?

# Urgency
- ?

# Steps to Test

1. Install stanford profile
2. Enable bean module 1.11
3. Create a new bean type and add a body field
4. Create a new bean and place it in to the left sidebar filling in each of the bean entity fields
5. See no duplicate title 
6. Check out bean 1.13 
7. Clear cache and revisit page with bean on it
8. See duplicate block title
9. Check out this branch of this module
10. Run drush updb to run upgrade path
11. Review page with bean block on it and see no page title.

# Affected Projects or Products
- Self serve

# Associated Issues and/or People
- SITES-1101

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)