### PR TITLE
SITES-365: Allow for installing on ACSF UI

### DIFF
--- a/stanford.profile
+++ b/stanford.profile
@@ -375,7 +375,7 @@ function stanford_acsf_tasks_ritm($install_vars) {
       drupal_form_submit('stanford_ssp_add_sso_user', $form_state);
     }
   }
-  
+
   // Set the site title.
   if ($site_name !== "default") {
     variable_set('site_name', check_plain($response['webSiteTitle']));

--- a/stanford.profile
+++ b/stanford.profile
@@ -375,9 +375,14 @@ function stanford_acsf_tasks_ritm($install_vars) {
       drupal_form_submit('stanford_ssp_add_sso_user', $form_state);
     }
   }
-
+  
   // Set the site title.
-  variable_set('site_name', check_plain($response['webSiteTitle']));
+  if ($site_name == "default") {
+    variable_set('site_name', 'Default');
+  }
+  else {
+    variable_set('site_name', check_plain($response['webSiteTitle']));
+  };
 
   // Set the site email.
   variable_set('site_mail', $email);

--- a/stanford.profile
+++ b/stanford.profile
@@ -314,11 +314,8 @@ function stanford_acsf_tasks_ritm($install_vars) {
     // If the request fails because the site that is being installed does not
     // exist in the API fetch the default information. This is useful when
     // installing a site directly through the ACSF dashboard.
-    if (!isset($response['sunetId'])) {
-      $site_name = "default";
-      $response = stanford_acsf_tasks_ritm_make_api_request($site_name);
-    }
-
+    $site_name = "default";
+    $response = stanford_acsf_tasks_ritm_make_api_request($site_name);
   }
 
   // If still no result die.

--- a/stanford.profile
+++ b/stanford.profile
@@ -377,12 +377,9 @@ function stanford_acsf_tasks_ritm($install_vars) {
   }
   
   // Set the site title.
-  if ($site_name == "default") {
-    variable_set('site_name', 'Default');
-  }
-  else {
+  if ($site_name !== "default") {
     variable_set('site_name', check_plain($response['webSiteTitle']));
-  };
+  }
 
   // Set the site email.
   variable_set('site_mail', $email);

--- a/stanford.profile
+++ b/stanford.profile
@@ -310,7 +310,6 @@ function stanford_acsf_tasks_ritm($install_vars) {
     $response = stanford_acsf_tasks_ritm_make_api_request($site_name);
   }
   catch (\Exception $e) {
-
     // If the request fails because the site that is being installed does not
     // exist in the API fetch the default information. This is useful when
     // installing a site directly through the ACSF dashboard.

--- a/stanford.profile
+++ b/stanford.profile
@@ -308,6 +308,15 @@ function stanford_acsf_tasks_ritm($install_vars) {
   // Fetch the information we need from the API.
   $response = stanford_acsf_tasks_ritm_make_api_request($site_name);
 
+  // If the request fails because the site that is being installed does not
+  // exist in the API fetch the default information. This is useful when
+  // installing a site directly through the ACSF dashboard.
+  if (!isset($response['sunetId'])) {
+    $site_name = "default";
+    stanford_acsf_tasks_ritm_make_api_request($site_name);
+  }
+
+  // If still no result die.
   if (!isset($response['sunetId'])) {
     throw new \Exception("No sunetId in response body from SNOW");
   }

--- a/stanford.profile
+++ b/stanford.profile
@@ -306,14 +306,19 @@ function stanford_acsf_tasks_ritm($install_vars) {
   }
 
   // Fetch the information we need from the API.
-  $response = stanford_acsf_tasks_ritm_make_api_request($site_name);
+  try {
+    $response = stanford_acsf_tasks_ritm_make_api_request($site_name);
+  }
+  catch (\Exception $e) {
 
-  // If the request fails because the site that is being installed does not
-  // exist in the API fetch the default information. This is useful when
-  // installing a site directly through the ACSF dashboard.
-  if (!isset($response['sunetId'])) {
-    $site_name = "default";
-    stanford_acsf_tasks_ritm_make_api_request($site_name);
+    // If the request fails because the site that is being installed does not
+    // exist in the API fetch the default information. This is useful when
+    // installing a site directly through the ACSF dashboard.
+    if (!isset($response['sunetId'])) {
+      $site_name = "default";
+      $response = stanford_acsf_tasks_ritm_make_api_request($site_name);
+    }
+
   }
 
   // If still no result die.
@@ -440,7 +445,7 @@ function stanford_acsf_tasks_ritm_make_api_request($site_name) {
 
   if ($curl_info['http_code'] !== 200) {
     watchdog('stanford', 'Failed to fetch information from SNOW api.', array(), WATCHDOG_ERROR);
-    throw new Exception("Failed to fetch information from SNOW api.");
+    throw new Exception("Failed to fetch information from SNOW api. NON 200 Response.");
   }
 
   if (empty($response) || ($err == 0 && !empty($errmsg))) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fetches a default site from the SNOW API when one is not found in the initial request.
- Allows for installing a site from elsewhere than the SNOW form.

# Needed By (Date)
- ?

# Urgency
- ?

# Steps to Test

1. This code is in branch SITES-365 in https://github.com/SU-SWS/acsf-cardinald7 and a slightly modified version is up on Acquia in branch SITES-365. The modified branch has adjusted the SNOW API endpoint to point to production while the test sites are out of commission.
2. Check out SITES-365 on dev or test of the ACSF environment
3. Create a new site
4. Wait for it to install
5. Continue to wait.
6. waaaaiiiit for it.
7. Check to see that it installed with default Information.
8. Try to log in with SAML

# Affected Projects or Products
- Errything.

# Associated Issues and/or People
- SITE-365

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)