### PR TITLE
SITES-365: Set site name to user's full name if on Leland stack

### DIFF
--- a/stanford.profile
+++ b/stanford.profile
@@ -390,10 +390,12 @@ function stanford_acsf_tasks_ritm($install_vars) {
 
     switch($stack) {
       case "02":
+        // Users request a Website Title for group/dept sites on the cardinald7 stack. Set the site_name to that value.
         variable_set('site_name', check_plain($response['webSiteTitle']));
         break;
 
       case "03":
+        // Users do not have the option to request a website title on the leland stack. Set it to the user's full name.
         variable_set('site_name', check_plain($response['fullName']));
         break;
 

--- a/stanford.profile
+++ b/stanford.profile
@@ -386,23 +386,24 @@ function stanford_acsf_tasks_ritm($install_vars) {
     if (!empty($ah_env) && is_string($ah_env)) {
       // Should return "02" or "03"
       $stack = substr($ah_env, 0, 2);
+      switch($stack) {
+        case "02":
+          variable_set('site_name', check_plain($response['webSiteTitle']));
+          break;
+
+        case "03":
+          variable_set('site_name', check_plain($response['fullName']));
+          break;
+
+        default:
+          variable_set('site_name', "default");
+
+      }
+    }
+    else {
+      variable_set('site_name', "default");
     }
 
-    switch($stack) {
-      case "02":
-        // Users request a Website Title for group/dept sites on the cardinald7 stack. Set the site_name to that value.
-        variable_set('site_name', check_plain($response['webSiteTitle']));
-        break;
-
-      case "03":
-        // Users do not have the option to request a website title on the leland stack. Set it to the user's full name.
-        variable_set('site_name', check_plain($response['fullName']));
-        break;
-
-      default:
-        variable_set('site_name', "default");
-
-    }
   }
 
   // Set the site email.

--- a/stanford.profile
+++ b/stanford.profile
@@ -378,7 +378,29 @@ function stanford_acsf_tasks_ritm($install_vars) {
 
   // Set the site title.
   if ($site_name !== "default") {
-    variable_set('site_name', check_plain($response['webSiteTitle']));
+
+    // Check for ACSF environment variable.
+    // Returns "02live", "02test", or "02dev" for cardinald7 stack.
+    // Returns "03live", "03test", or "03dev" for leland stack.
+    $ah_env = getenv('AH_SITE_ENVIRONMENT');
+    if (!empty($ah_env) && is_string($ah_env)) {
+      // Should return "02" or "03"
+      $stack = substr($ah_env, 0, 2);
+    }
+
+    switch($stack) {
+      case "02":
+        variable_set('site_name', check_plain($response['webSiteTitle']));
+        break;
+
+      case "03":
+        variable_set('site_name', check_plain($response['fullName']));
+        break;
+
+      default:
+        variable_set('site_name', "default");
+
+    }
   }
 
   // Set the site email.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set the site name correctly on Leland

# Needed By (Date)
- The sooner this is merged, the more RSI I avoid

# Criticality
- How critical is this PR on a 1-10 scale? Eleventy

# Steps to Test

1. The `SITES-365` branch of the acsf-leland codebase contains this change and is checked out on ACSF dev
2. Go to https://stanforddev.service-now.com/it_services?id=sc_cat_item&sys_id=3e68b90b13cfcf00d3b6b3b12244b062
3. Submit the form
4. Wait ~10 minutes, or monitor the task log in ACSF dev
5. Go to https://sheamck-dev.people.stanford.edu
6. Ensure that the site title is set to "Shea McKinney"
6. Ensure that the site email address is set to sheamck@stanford.edu

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: SITES-365
- Other PRs: #120 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)