### PR TITLE
SITES-1223: Unblock stanford_sites modules

### DIFF
--- a/stanford.profile
+++ b/stanford.profile
@@ -804,7 +804,6 @@ function stanford_system_info_alter(&$info, $file, $type) {
     preg_match("/Stanford Paragraph/", $info['name']) ||
     preg_match("/Stanford Private Page/", $info['name']) ||
     preg_match("/Stanford Related/", $info['name']) ||
-    preg_match("/Stanford Site/", $info['name']) ||
     preg_match("/Stanford Story Page/", $info['name']) ||
     preg_match("/Stanford Subsite/", $info['name']) ||
     preg_match("/Stanford Jumpstart/", $info['name']) ||


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow stanford_sites_helper and stanford_sites_systemtools to run

# Needed By (Date)
- Next week sometime?

# Criticality
- How critical is this PR on a 1-10 scale? 4/10

# Steps to Test

1. Check out this branch and https://github.com/SU-SWS/SU-IT-Services/pull/15
2. drush -y si stanford
3. Go to `admin/modules`
4. Filter by `sites`
5. Verify that Stanford Sites Helper and Stanford Sites System Tools cannot be enabled in the GUI
6. `drush pmi stanford_sites_helper && drush pmi stanford_sites_systemtools` and ensure that they are both enabled

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-1223
- Other PRs: https://github.com/SU-SWS/SU-IT-Services/pull/15

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

