### PR TITLE
Block a few additional modules

### DIFF
--- a/stanford.profile
+++ b/stanford.profile
@@ -807,6 +807,8 @@ function stanford_system_info_alter(&$info, $file, $type) {
     preg_match("/Stanford Story Page/", $info['name']) ||
     preg_match("/Stanford Subsite/", $info['name']) ||
     preg_match("/Stanford Jumpstart/", $info['name']) ||
+    preg_match("/Stanford Sites Jumpstart/", $info['name']) ||
+    preg_match("/Stanford Site Actions/", $info['name']) ||
     preg_match("/Stanford JSA/", $info['name']) ||
     preg_match("/VPSA/", $info['name']))
   ) {


### PR DESCRIPTION
# READY FOR REVIEW

Go to https://deletemedept20190723.sites.stanford.edu/admin/modules and filter for "jump". You'll see that there are a few modules that we're not blocking. We should block them in this profile.